### PR TITLE
fix an issue where the socket path can get too long

### DIFF
--- a/anspass-lib.c
+++ b/anspass-lib.c
@@ -88,7 +88,6 @@ int setup_socket(struct anspass_info *info) {
 		goto file_exists;
 
 	info->s_name->sun_family = AF_UNIX;
-	strcat(info->s_name->sun_path, info->env_path);
 	strcat(info->s_name->sun_path, SOCKET_NAME);
 
 

--- a/anspass-lib.h
+++ b/anspass-lib.h
@@ -35,7 +35,7 @@
 
 #define MAX_PASSWD_ATTEMPT      3
 #define MAX_MSG_LENGTH          1024
-#define SOCKET_NAME             "/socket"
+#define SOCKET_NAME             "./socket"
 
 #define TOKEN_LEN               16
 
@@ -66,6 +66,7 @@ struct anspass_info {
 	int socket;
 	int running;
 	char *env_path;
+	char *old_path;
 };
 
 int is_env_set();

--- a/anspass.c
+++ b/anspass.c
@@ -1,4 +1,5 @@
 #include "anspass.h"
+#include <errno.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <sys/un.h>
@@ -63,6 +64,16 @@ int main(int argc, char *argv[]) {
 		goto env_path_dne;
 	}
 
+	info.old_path = getcwd(NULL, 0);
+	if (!info.old_path)
+		goto no_old_path;
+
+	if (chdir((const char *)info.env_path) < 0)
+	{
+		printf("Change dir %s failed: %s\n", info.env_path, strerror(errno));
+		goto chdir_fail;
+	}
+
 	env = getenv(ANSPASS_TOKEN);
 
 	if (strlen(env) != TOKEN_LEN)
@@ -120,6 +131,10 @@ socket_fail:
 no_token_mem:
 token_len_mismatch:
 env_path_dne:
+	chdir((const char *)info.old_path);
+chdir_fail:
+	free(info.old_path);
+no_old_path:
 	free(info.env_path);
 no_env_path:
 	free(msg);

--- a/anspassd.c
+++ b/anspassd.c
@@ -1,6 +1,7 @@
 #include "anspassd.h"
 #include "anspass-lib.h"
 #include <errno.h>
+#include <string.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -32,6 +33,16 @@ int main(int argv, char *argc[]) {
 	{
 		printf("Error: Failed to create %s: %d\n", info.env_path, ret);
 		goto env_path_dne;
+	}
+
+	info.old_path = getcwd(NULL, 0);
+	if (!info.old_path)
+		goto no_old_path;
+
+        if (chdir((const char *)info.env_path) < 0)
+	{
+		printf("Change dir %s failed: %s\n", info.env_path, strerror(errno));
+		goto chdir_fail;
 	}
 
 	info.token = (char*)calloc(1, sizeof(char)*TOKEN_LEN+1);
@@ -103,6 +114,10 @@ db1_fail:
 no_tmp_token:
 	free(info.token);
 no_token:
+	chdir((const char *)info.old_path);
+chdir_fail:
+	free(info.old_path);
+no_old_path:
 env_path_dne:
 	free(info.env_path);
 no_env_path:


### PR DESCRIPTION
[github bug #1]

Changes into the socket directory, then opens the socket with a simple name.

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
Signed-off-by: Mark Hatle <mark.hatle@windriver.com>